### PR TITLE
Fixes an error when "parent" is null

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -113,7 +113,9 @@ function onTrayIconAdded(o, icon, role, delay=500) {
 
 function onTrayIconRemoved(o, icon) {
     let parent = icon.get_parent();
-    parent.destroy();
+    if (parent !== null) {
+        parent.destroy();
+    }
     icon.destroy();
     icons.splice(icons.indexOf(icon), 1);
 


### PR DESCRIPTION
Sometimes, the extension shows this error:

(gnome-shell:21286): Gjs-WARNING **: JS ERROR: TypeError: parent is null
onTrayIconRemoved@/home/raster/.local/share/gnome-shell/extensions/TopIcons@phocean.net/extension.js:116

This patch fixes it.