### PR TITLE
Fix redeclaration error with Gnome 3.24

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -231,14 +231,14 @@ function setIcon(icon) {
 
     icon.opacity = opacityValue;
 
-    let effect = new Clutter.DesaturateEffect({factor : desaturationValue});
-    effect.set_factor(desaturationValue);
-    icon.add_effect_with_name('desaturate', effect);
+    let sat_effect = new Clutter.DesaturateEffect({factor : desaturationValue});
+    sat_effect.set_factor(desaturationValue);
+    icon.add_effect_with_name('desaturate', sat_effect);
 
-    let effect = new Clutter.BrightnessContrastEffect({});
-    effect.set_brightness(brightnessValue);
-    effect.set_contrast(contrastValue);
-    icon.add_effect_with_name('brightness-contrast',effect);
+    let bright_effect = new Clutter.BrightnessContrastEffect({});
+    bright_effect.set_brightness(brightnessValue);
+    bright_effect.set_contrast(contrastValue);
+    icon.add_effect_with_name('brightness-contrast', bright_effect);
 
 }
 


### PR DESCRIPTION
Gnome 3.24 appears to have enabled strict mode, so doing `let effect` twice blows up.

```
 JS ERROR: Exception in callback for signal: extension-found: TypeError: redeclaration of let effect
 initExtension@resource:///org/gnome/shell/ui/extensionSystem.js:221:5
 loadExtension@resource:///org/gnome/shell/ui/extensionSystem.js:168:18
 _loadExtensions/<@resource:///org/gnome/shell/ui/extensionSystem.js:304:9
 _emit@resource:///org/gnome/gjs/modules/signals.js:124:27
 ExtensionFinder<._loadExtension@resource:///org/gnome/shell/misc/extensionUtils.js:184:9
 wrapper@resource:///org/gnome/gjs/modules/lang.js:178:22
 bind/<@resource:///org/gnome/gjs/modules/lang.js:95:16
 collectFromDatadirs@resource:///org/gnome/shell/misc/fileUtils.js:27:1
 ExtensionFinder<.scanExtensions@resource:///org/gnome/shell/misc/extensionUtils.js:189:9
 wrapper@resource:///org/gnome/gjs/modules/lang.js:178:22
 _loadExtensions@resource:///org/gnome/shell/ui/extensionSystem.js:306:5
 enableAllExtensions@resource:///org/gnome/shell/ui/extensionSystem.js:314:9
 _sessionUpdated@resource:///org/gnome/shell/ui/extensionSystem.js:345:9
 init@resource:///org/gnome/shell/ui/extensionSystem.js:353:5
 _initializeUI@resource:///org/gnome/shell/ui/main.js:219:5
 start@resource:///org/gnome/shell/ui/main.js:127:5
 @<main>:1:31
```

Fixes https://github.com/phocean/TopIcons-plus/issues/51

Signed-off-by: Joel Stanley <joel@jms.id.au>