### PR TITLE
Clean up blacklist handling a bit

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -38,7 +38,7 @@ let trayRemovedId = 0;
 let icons = [];
 let iconsBoxLayout = null;
 let iconsContainer = null;
-let blacklist = ["skype","SkypeNotification@chrisss404.gmail.com"]; // blacklist: array of uuid and wmClass (icon application name)
+let blacklist = [["skype","SkypeNotification@chrisss404.gmail.com"]]; // blacklist: array of [uuid, wmClass (icon application name)] pairs
 
 function init() { }
 
@@ -68,9 +68,11 @@ function disable() {
 function onTrayIconAdded(o, icon, role, delay=1000) {
 
     // loop through the array and hide the extension if extension X is enabled and corresponding application is running
-    let wmClass = icon.wm_class ? icon.wm_class.toLowerCase() : '';
-    for (let i = 0; i < blacklist.length; i++) {
-        if (ExtensionUtils.extensions[blacklist[i+1]] !== undefined && ExtensionUtils.extensions[blacklist[i+1]].state === 1 && wmClass === blacklist[i])
+    let iconWmClass = icon.wm_class ? icon.wm_class.toLowerCase() : '';
+    for (let [wmClass, uuid] of blacklist) {
+        if (ExtensionUtils.extensions[uuid] !== undefined &&
+            ExtensionUtils.extensions[uuid].state === 1 &&
+            iconWmClass === wmClass)
             return;
     }
 


### PR DESCRIPTION
I stumbled upon this code when looking into adjusting the extension for the     legacy tray removal in GNOME. I suggest using destructuring when processing the blacklist, as it results in much more readable code in my opinion.

This will also take care of a warning with recent gjs versions about trying to  access elements outside the bounds of the array.