### PR TITLE
Makefile: add 'all' default target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 INSTALL_PATH = ~/.local/share/gnome-shell/extensions
 INSTALL_NAME = TopIcons@phocean.net
 
+all: build
+
 install: build
 	rm -rf $(INSTALL_PATH)/$(INSTALL_NAME)
 	mkdir -p $(INSTALL_PATH)/$(INSTALL_NAME)


### PR DESCRIPTION
- put 'build' as default target to make it default

The current Makefile will install just running 'make' without any argument. I believe this behavior may lead users to install it unintentionally.