### PR TITLE
Fix TopIcons no longer working with gnome-shell < 3.33.90

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -82,9 +82,18 @@ function onTrayIconAdded(o, icon, role, delay=1000) {
     // loop through the array and hide the extension if extension X is enabled and corresponding application is running
     let iconWmClass = icon.wm_class ? icon.wm_class.toLowerCase() : '';
     for (let [wmClass, uuid] of blacklist) {
-        if (Main.extensionManager.lookup(uuid) &&
-            iconWmClass === wmClass)
-            return;
+        if (Main.extensionManager === undefined) {
+            // For gnome-shell < 3.33.90
+            if (ExtensionUtils.extensions[uuid] !== undefined &&
+                ExtensionUtils.extensions[uuid].state === 1 &&
+                iconWmClass === wmClass)
+                return;
+        } else {
+            // For gnome-shell >= 3.33.90
+            if (Main.extensionManager.lookup(uuid) &&
+                iconWmClass === wmClass)
+                return;
+        }
     }
 
     let iconContainer = new St.Button({child: icon, visible: false});


### PR DESCRIPTION
This fixes the following error:
gnome-shell: JS ERROR: TypeError: Main.extensionManager is undefined
onTrayIconAdded@/usr/share/gnome-shell/extensions/TopIcons@phocean.net/extension.js:85:1

Related:
https://github.com/phocean/TopIcons-plus/commit/43f991d1533e8d4002bd25ae6afd8a1568c39b36#diff-06f1274e40de25abda72d812b1cce86a
https://bugzilla.redhat.com/show_bug.cgi?id=1767544