### PR TITLE
Declare compatibility with GNOME Shell 41, 42, 43

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,10 @@
   "name": "TopIcons Plus",
   "gettext-domain": "TopIcons-Plus",
   "shell-version": [
-    "40"
+    "40",
+    "41",
+    "42",
+    "43"
   ],
   "settings-schema": "org.gnome.shell.extensions.topicons",
   "url": "https://github.com/phocean/TopIcons-plus",


### PR DESCRIPTION
From some brief testing, this extension seems to be compatible without
further changes.

Bug-Debian: https://bugs.debian.org/996073  
Bug-Debian: https://bugs.debian.org/1008559  
Bug-Debian: https://bugs.debian.org/1018282